### PR TITLE
Patch devicePixelContentBoxSize from draft spec

### DIFF
--- a/src/ExtendedResizeObserverEntry.ts
+++ b/src/ExtendedResizeObserverEntry.ts
@@ -1,5 +1,6 @@
 import { ObservedElement } from './ObservedElement';
 
 export interface ExtendedResizeObserverEntry extends ResizeObserverEntry {
+  readonly devicePixelContentBoxSize: ReadonlyArray<ResizeObserverSize>; // https://github.com/w3c/csswg-drafts/pull/4476
   target: ObservedElement;
 }


### PR DESCRIPTION
## Context

The draft spec specifies a `device-pixel-content-box` box size. This box size is not available in TS 4.2, so this PR patches the `ExtendedResizeObserverEntry` type to include it.

## Changes

* Added `devicePixelContentBoxSize` to the `ResizeObserverEntry` extension.